### PR TITLE
RUNNING CI

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -21,12 +21,10 @@ jobs:
     env:
       REGISTRY: localhost:5000
     strategy:
+      fail-fast: false
       matrix:
-        # Run tests on oldest and newest supported OCP Kubernetes
-        # - OCP 4.5 runs Kubernetes v1.18
-        # KinD tags: https://hub.docker.com/r/kindest/node/tags
         kind:
-          - 'v1.18.15'
+          - 'minimum'
           - 'latest'
     name: KinD tests
     steps:
@@ -61,8 +59,10 @@ jobs:
         make test
 
     - name: Create K8s KinD Cluster - ${{ matrix.kind }}
+      # Overwrite "minimum" with an actual tag; OCP 4.8 runs Kubernetes v1.21
+      # KinD tags: https://hub.docker.com/r/kindest/node/tags
       env:
-        KIND_VERSION: ${{ matrix.kind }}
+        KIND_VERSION: ${{ matrix.kind == 'minimum' && 'v1.21.14' || matrix.kind }}
       run: |
         make kind-bootstrap-cluster-dev
 

--- a/README.md
+++ b/README.md
@@ -80,5 +80,5 @@ any of the Kustomize files, you may regenerate `deploy/operator.yaml` by running
 - The `governance-policy-framework-addon` is part of the `open-cluster-management` community. For more information, visit: [open-cluster-management.io](https://open-cluster-management.io).
 
 <!---
-Date: 11/16/2021
+Date: 2022-11-28
 -->

--- a/controllers/templatesync/template_sync.go
+++ b/controllers/templatesync/template_sync.go
@@ -140,6 +140,13 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, request reconcile.Requ
 			Name:      dep.Name,
 		}
 
+		// Use cluster namespace for known policy types when the namespace is blank
+		if depID.Namespace == "" && depID.Group == policiesv1.GroupVersion.Group &&
+			depID.Version == policiesv1.GroupVersion.Version &&
+			strings.HasSuffix(depID.Kind, "Policy") {
+			depID.Namespace = request.Namespace
+		}
+
 		existingDep, ok := topLevelDeps[depID]
 		if ok && existingDep != dep.Compliance {
 			err := fmt.Errorf("dependency on %s has conflicting compliance states", dep.Name)
@@ -176,6 +183,13 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, request reconcile.Requ
 				Kind:      dep.GroupVersionKind().Kind,
 				Namespace: dep.Namespace,
 				Name:      dep.Name,
+			}
+
+			// Use cluster namespace for known policy types when the namespace is blank
+			if depID.Namespace == "" && depID.Group == policiesv1.GroupVersion.Group &&
+				depID.Version == policiesv1.GroupVersion.Version &&
+				strings.HasSuffix(depID.Kind, "Policy") {
+				depID.Namespace = request.Namespace
 			}
 
 			existingDep, ok := templateDeps[depID]

--- a/test/e2e/case4_status_merge_test.go
+++ b/test/e2e/case4_status_merge_test.go
@@ -4,6 +4,8 @@
 package e2e
 
 import (
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -100,6 +102,8 @@ var _ = Describe("Test status sync with multiple templates", func() {
 
 			return getCompliant(managedPlc)
 		}, defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
+		// Wait for slow events to show up, otherwise the delete might not get all of them.
+		time.Sleep(10 * time.Second)
 		By("Delete events in ns:" + clusterNamespace)
 		_, err := kubectlManaged(
 			"delete",


### PR DESCRIPTION
Our known policy types only exist in the managed cluster namespace here. Since that name can not be known by the policy author, the "correct" value is to leave it empty. But when creating the dependency watches, a namespace must be specified. This uses the cluster namespace in that situation.

Previous work:
 - https://github.com/open-cluster-management-io/governance-policy-framework-addon/pull/15

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>